### PR TITLE
fix: Use short club names during athlete import

### DIFF
--- a/Import/Fun_BibImport.php
+++ b/Import/Fun_BibImport.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__ . '/../Lookup/Fun_ClubName.php';
+
 /**
  * Fun_BibImport.php — Processing functions for the BibImport feature.
  *
@@ -289,7 +291,7 @@ function pl_bibimport_run($tourId, $rawInput, $division) {
             $coId = pl_bibimport_upsert_country(
                 $tourId,
                 $lue->LueCountry,
-                $lue->LueCoDescr,
+                pl_club_short_name($lue->LueCoDescr),
                 $countryCache
             );
 


### PR DESCRIPTION
Ensure club descriptions are processed through `pl_club_short_name` during the bib import process to maintain consistent naming conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced batch import process to use standardized club short names for country record updates, improving data consistency and accuracy during bulk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->