### PR TITLE
fix: Correct Quarter-Final elimination ranking positions

### DIFF
--- a/Rank/Obj_Rank_FinalInd_calc.php
+++ b/Rank/Obj_Rank_FinalInd_calc.php
@@ -297,10 +297,10 @@
 
 						if ($realphase == 4)
 						{
-							// QF: account for pool-elimination brackets (EvElimType 3/4) that
-							// have fewer than 8 losers; start as close to the bottom as possible.
-							$MaxRank = ($myRow->EvElimType == 3 || $myRow->EvElimType == 4) ? 4 : 8;
-							$pos = max(4, $MaxRank - safe_num_rows($rs));
+							// QF: always start at position 4 (the 4 slots that advanced past QF).
+							// Using safe_num_rows() to adjust the start caused ranks 7-8 instead
+							// of 5-6 when byes reduced the real loser count below 4.
+							$pos = 4;
 						}
 						elseif ($realphase > 4)
 						{

--- a/Rank/Obj_Rank_FinalTeam_calc.php
+++ b/Rank/Obj_Rank_FinalTeam_calc.php
@@ -237,7 +237,10 @@
 
 						if ($realphase == 4)
 						{
-							$pos = max(4, 8 - safe_num_rows($rs));
+							// QF: always start at position 4 (the 4 slots that advanced past QF).
+							// Using safe_num_rows() to adjust the start caused ranks 7-8 instead
+							// of 5-6 when byes reduced the real loser count below 4.
+							$pos = 4;
 						}
 						elseif ($realphase > 4)
 						{


### PR DESCRIPTION
Ensure that Quarter-Final losers are ranked correctly (positions 5-8) even when byes are present. Previously, calculating the starting position based on the number of actual participants caused incorrect rank offsets when the bracket was not full.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect rank numbering in knockout rounds that occurred when tournament byes were present in the bracket. Quarterfinal rank assignments now display with consistent accuracy. The new standardized approach ensures proper sequential ranking regardless of bracket configuration, improving rank display reliability. Both individual and team competition rankings are now consistently calculated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->